### PR TITLE
feat: Add event report generation feature

### DIFF
--- a/templates/dashboard_admin.html
+++ b/templates/dashboard_admin.html
@@ -164,6 +164,7 @@
                     <div class="btn-container">
                         <a href="{{ url_for('logout') }}" class="btn btn-logout">Sair</a>
                         <a href="{{ url_for('criar_oficina') }}" class="btn btn-create">+ Criar Nova Oficina</a>
+                        <a href="{{ url_for('gerar_relatorio_evento') }}" class="btn btn-info">Gerar Relatório do Evento</a>
                     </div>
                 </ul>
             </div>


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to generate a comprehensive event report in PDF format.

The report includes:
- A summary of key metrics: total users, workshops, enrollments, and check-ins.
- A detailed breakdown of each workshop, including the number of enrollments, check-ins, and the adhesion rate.

A new route `/gerar_relatorio_evento` has been added to handle the report generation. A button has also been added to the admin dashboard to make this feature easily accessible.